### PR TITLE
fixed the field map intensity shift caused by missing normalization within local mask

### DIFF
--- a/qsm_forward/qsm_forward.py
+++ b/qsm_forward/qsm_forward.py
@@ -455,7 +455,7 @@ def generate_bids(tissue_params: TissueParams, recon_params: ReconParams, bids_d
     print("Done!")
 
 
-def generate_field(chi, mask, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
+def generate_field(chi, mask=None, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
     """
     Perform the forward convolution operation.
 
@@ -465,6 +465,12 @@ def generate_field(chi, mask, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
     ----------
     chi : numpy.ndarray
         The susceptibility distribution array.
+    mask : numpy.ndarray
+        A binary mask that indicates the internal region of interest.
+    voxel_size : list, optional
+        The voxel size. Default is [1, 1, 1].
+    B0_dir : list, optional
+        The B0 direction. Default is [0, 0, 1].
 
     Returns
     -------
@@ -479,7 +485,8 @@ def generate_field(chi, mask, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
     chitemp[:dims[0], :dims[1], :dims[2]] = chi
     field = np.real(np.fft.ifftn(np.fft.fftn(chitemp) * D))
     field = field[:dims[0], :dims[1], :dims[2]]
-    field = field - np.mean(field[mask != 0])
+    if mask is not None:
+        field = field - np.mean(field[mask != 0])
 
     return field
 

--- a/qsm_forward/qsm_forward.py
+++ b/qsm_forward/qsm_forward.py
@@ -331,10 +331,10 @@ def generate_bids(tissue_params: TissueParams, recon_params: ReconParams, bids_d
 
     # calculate field
     print("Computing field model...")
-    field = generate_field(tissue_params.chi.get_fdata(), voxel_size=tissue_params.voxel_size, B0_dir=recon_params.B0_dir)
+    field = generate_field(tissue_params.chi.get_fdata(), tissue_params.mask.get_fdata(),voxel_size=tissue_params.voxel_size, B0_dir=recon_params.B0_dir)
     if save_field:
         nib.save(resize(nib.Nifti1Image(dataobj=np.array(field, dtype=np.float32), affine=tissue_params.nii_affine, header=tissue_params.nii_header), recon_params.voxel_size), filename=os.path.join(subject_dir_deriv, "anat", f"{recon_name}_fieldmap.nii"))
-        local_field = generate_field(tissue_params.chi.get_fdata() * tissue_params.mask.get_fdata(), voxel_size=tissue_params.voxel_size, B0_dir=recon_params.B0_dir)
+        local_field = generate_field(tissue_params.chi.get_fdata() * tissue_params.mask.get_fdata(), tissue_params.mask.get_fdata(), voxel_size=tissue_params.voxel_size, B0_dir=recon_params.B0_dir)
         nib.save(resize(nib.Nifti1Image(dataobj=np.array(local_field, dtype=np.float32), affine=tissue_params.nii_affine, header=tissue_params.nii_header), recon_params.voxel_size), filename=os.path.join(subject_dir_deriv, "anat", f"{recon_name}_fieldmap-local.nii"))
 
     # simulate shim field
@@ -455,7 +455,7 @@ def generate_bids(tissue_params: TissueParams, recon_params: ReconParams, bids_d
     print("Done!")
 
 
-def generate_field(chi, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
+def generate_field(chi, mask, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
     """
     Perform the forward convolution operation.
 
@@ -479,6 +479,7 @@ def generate_field(chi, voxel_size=[1, 1, 1], B0_dir=[0, 0, 1]):
     chitemp[:dims[0], :dims[1], :dims[2]] = chi
     field = np.real(np.fft.ifftn(np.fft.fftn(chitemp) * D))
     field = field[:dims[0], :dims[1], :dims[2]]
+    field = field - np.mean(field[mask != 0])
 
     return field
 


### PR DESCRIPTION
***Bug found***
When simulating a field map from challenge data, this Python package generates different field maps from Matlab, as shown in the following, the intensity is shifted 
![image](https://github.com/user-attachments/assets/512af5c3-d92c-480c-8173-fe16b951e2b9)

---------------------------------------

***Bug fixed***
In Matlab, there is a normalization within the local brain; now added this into Python, as shown in the following. Also pasted what described in the challenge paper
![image](https://github.com/user-attachments/assets/e2a2844a-d6e2-4235-aa13-d854d3d378c7)
